### PR TITLE
fix(ci): bump lock-threads to v6.0.2 for new github-token format

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -17,7 +17,7 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771 # v5
+      - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c # v6.0.2
         with:
           issue-inactive-days: 0
           pr-inactive-days: 0


### PR DESCRIPTION
## Problem

The scheduled **Lock Threads** workflow fails on every run ([example](https://github.com/sanity-io/sanity-template-ecommerce-studio/actions/runs/27245677058)) with:

> "github-token" length must be less than or equal to 100 characters long

`dessant/lock-threads@v5` validates that the token is ≤100 characters, and GitHub's auto-generated `GITHUB_TOKEN` now exceeds that. The run also warns that v5 runs on the deprecated Node.js 20 runtime.

## Fix

Bump the pinned SHA to `v6.0.2`, which:
- updates the `github-token` validation schema to accept the new token format (dessant/lock-threads#55, fixed in v6.0.2)
- runs on Node.js 24 (v6.0.0), clearing the deprecation warning

## Verification

`workflow_dispatch` run from this branch completed successfully: https://github.com/sanity-io/sanity-template-ecommerce-studio/actions/runs/27249867135

🤖 Generated with [Claude Code](https://claude.com/claude-code)